### PR TITLE
remove duplicate echo of ttyACM0 - in case more than one ttyACM* devi…

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -5,8 +5,6 @@ function detect_zigbee_device {
 		usb_dev_count=$(ls -1 /dev/ttyACM* 2>/dev/null | wc -l)
 		if [ "$usb_dev_count" -gt 1 ]; then
 			>&2 echo "There are multiple devices connected, that could be Zigbee USB adaptors. Please check data/zigbee/configuration.yml, if the device is wrong. /dev/ttyACM0 is used as the default."
-
-			echo "/dev/ttyACM0"
 		fi
 
 		if [ -c /dev/ttyACM0 ]; then


### PR DESCRIPTION
in case more than one ttyACM* device is found, the echo statement was executed twice, resulting in the following error in line 118 of the script:

./start.sh: line 118: [: too many arguments